### PR TITLE
Typo and better path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a small [Next.js](https://nextjs.org/) fullstack app that allows you to 
 First, clone the repository and install the dependencies:
 
 ```bash
-npm run i
+npm i
 ```
 
 Then, run the development server:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,8 +1,9 @@
+import { join } from "path";
+
 import { CSSProperties } from "react";
 
 // Basic scrollable column of images
-
-export const ROOT_DIRECTORY = `${process.cwd()}/samples`; // Can be absolute or relative to the project root
+export const ROOT_DIRECTORY = join(process.cwd(), "samples"); // Can be absolute or relative to the project root
 export const RECURSIVE = true;
 export const MAX_IMAGES = 8;
 export const POLL_INTERVAL = 5 * 1000; // 5 seconds

--- a/src/config/phantom-screen.ts
+++ b/src/config/phantom-screen.ts
@@ -1,8 +1,9 @@
+import { join } from "path";
+
 import { CSSProperties } from "react";
 
-// Sample configuration for the `stairs/wall screen` at Phantom
-
-export const ROOT_DIRECTORY = `${process.cwd()}/samples`; // Can be absolute or relative to the project root
+// Basic scrollable column of images
+export const ROOT_DIRECTORY = join(process.cwd(), "samples");
 export const RECURSIVE = true;
 export const MAX_IMAGES = 8;
 export const POLL_INTERVAL = 5 * 1000; // 5 seconds


### PR DESCRIPTION
- Path configuration using `path.join`.
- Readme typo